### PR TITLE
Word Break Bug Fix: DogeOverview

### DIFF
--- a/resources/js/pages/Home.vue
+++ b/resources/js/pages/Home.vue
@@ -450,5 +450,8 @@ section.feature-section{
     font-size: 1.2rem;
   }
 
+  .asset-grid{
+    word-break: break-word;
+  }
 }
 </style>


### PR DESCRIPTION
Fix word-break issue for Media Sizes less than 400px on Asset Grid element